### PR TITLE
Dropbox API v2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ into. If the local folder does not exist **DBdownload** will create it, if it
 is used, it will be cleared first.
 
     $ dbdownload -s test -t /tmp/test
-    URL: https://www.dropbox.com/1/oauth/authorize?oauth_token=fjlkadf8a7dfjxy
-    Please authorize this URL in the browser and then press enter
+    1. Go to: https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=6m8gx7bmf2yawbm
+    2. Click "Allow" (you might have to log in first).
+    3. Copy the authorization code.
+    Enter the authorization code here:
 
 If this is the first time **DBdownload** is started, it will request access to
 your Dropbox data. Just open the link in your browser:
@@ -51,9 +53,9 @@ and allow access to your Dropbox:
 
 ![Dropbox authentication](http://nilvec.com/static/images/db_oauth_success.png)
 
-Get back to the console, press enter, and if you have allowed access,
-**DBdownload** should start synchronizing your Dropbox source folder to the
-target directory.
+Get back to the console, paste the authorization code you were given, and if you
+have allowed access, **DBdownload** should start synchronizing your Dropbox source 
+folder to the target directory.
 
 **DBdownload** has quite some flags and optional parameters, check them out:
 

--- a/dbdownload/dbdownload.py
+++ b/dbdownload/dbdownload.py
@@ -96,8 +96,8 @@ class DBDownload(object):
             try:
                 oauth_result = auth_flow.finish(auth_code)
             except Exception:
-                self._logger.exception("")
-                return
+                self._logger.error("Invalid authorization code. Exiting.")
+                sys.exit(1)
             self._token = oauth_result.access_token
 
         self.client = dropbox.Dropbox(self._token)

--- a/dbdownload/dbdownload.py
+++ b/dbdownload/dbdownload.py
@@ -100,7 +100,11 @@ class DBDownload(object):
                 sys.exit(1)
             self._token = oauth_result.access_token
 
-        self.client = dropbox.Dropbox(self._token)
+        try:
+            self.client = dropbox.Dropbox(self._token)
+        except Exception as e:
+            self._logger.exception("Unable to connect to Dropbox.")
+            sys.exit(1)
 
     def reset(self):
         self._logger.debug('resetting local state')

--- a/dbdownload/dbdownload.py
+++ b/dbdownload/dbdownload.py
@@ -12,15 +12,10 @@ from base64 import b64decode
 from ConfigParser import SafeConfigParser
 from optparse import OptionParser
 
-from dateutil import parser as timeparser
-from dateutil import tz as timezone
-from dropbox import client, session
+import dropbox
+import jsonpickle
 
 # Globals.
-# Got encoded dropbox app key at
-# https://dl-web.dropbox.com/spa/pjlfdak1tmznswp/api_keys.js/public/index.html
-APP_KEY = 'bYeHLWKRctA=|ld63MffhrcyQrbyLTeKvTqxE5cQ3ed1YL2q87GOL/g=='
-ACCESS_TYPE = 'dropbox'  # should be 'dropbox' or 'app_folder'
 LOGGER = 'dbdownload'
 VERSION = '0.0'
 
@@ -36,35 +31,9 @@ else:
         pass
 
 
-def decode_dropbox_key(key):
-    key, secret = key.split('|')
-    key = b64decode(key)
-    key = [ord(x) for x in key]
-    secret = b64decode(secret)
-
-    s = range(256)
-    y = 0
-    for x in xrange(256):
-        y = (y + s[len(key)] + key[x % len(key)]) % 256
-        s[x], s[y] = s[y], s[x]
-
-    x = y = 0
-    result = []
-    for z in range(len(secret)):
-        x = (x + 1) % 256
-        y = (y + s[x]) % 256
-        s[x], s[y] = s[y], s[x]
-        k = s[(s[x] + s[y]) % 256]
-        result.append(chr((k ^ ord(secret[z])) % 256))
-
-    # key = ''.join([chr(a) for a in key])
-    # return '|'.join([b64encode(key), b64encode(''.join(result))])
-    return ''.join(result).split('?', 2)
-
-
 class DBDownload(object):
 
-    def __init__(self, remote_dir, local_dir, cache_file, sleep=600, prg=None):
+    def __init__(self, remote_dir, local_dir, cache_file, token, sleep=600, prg=None):
         self._logger = logging.getLogger(LOGGER)
 
         self.remote_dir = remote_dir.lower()
@@ -83,17 +52,11 @@ class DBDownload(object):
         self.executable = prg
 
         self._tree = {}
-        self._token = None
+        self._token = token
         self._cursor = None
         self._load_state()
 
-        key, secret = decode_dropbox_key(APP_KEY)
-        self.sess = DBSession(key, secret, access_type=ACCESS_TYPE)
-        if self._token:
-            self.sess.set_token(self._token[0], self._token[1])
-        else:
-            self._token = self.sess.link()
-        self.client = client.DropboxClient(self.sess)
+        self.client = dropbox.Dropbox(self._token)
 
     def reset(self):
         self._logger.debug('resetting local state')
@@ -129,29 +92,28 @@ class DBDownload(object):
         self._mkdir(self.local_dir)  # Make sure root directory exists.
 
         tree = {}
-        changed = False
         while True:
             # Check for anything missing locally.
             changed = self._check_missing()
 
-            # Get delta results from Dropbox.
+            # If we don't have a cursor yet, call files_list_folder
             try:
-                result = self.client.delta(cursor=self._cursor)
+                if self._cursor is None:
+                    result = self.client.files_list_folder(self.remote_dir, recursive=True)
+                else:
+                    result = self.client.files_list_folder_continue(self._cursor)
             except Exception as e:
-                self._logger.error('error getting delta')
+                self._logger.error('error getting file list')
                 self._logger.exception(e)
                 continue
-            if result['reset']:
-                self._logger.debug('delta reset')
 
-            for path, metadata in result['entries']:
-                if os.path.commonprefix([
-                        path, self.remote_dir]) == self.remote_dir:
-                    tree[path] = metadata
+            for entry in result.entries:
+                if os.path.commonprefix([entry.path_lower, self.remote_dir]) == self.remote_dir:
+                    tree[entry.path_lower] = entry
 
-            self._cursor = result['cursor']
+            self._cursor = result.cursor
 
-            if not result['has_more']:
+            if not result.has_more:
                 if tree:
                     self._apply_delta(tree)
                     merged = dict(self._tree.items() + tree.items())
@@ -168,7 +130,7 @@ class DBDownload(object):
 
                 # Done processing delta, sleep and check again.
                 tree = {}
-                self._logger.debug('sleeping for %d seconds' % (self.sleep))
+                self._logger.debug('sleeping for %d seconds' % self.sleep)
                 time.sleep(self.sleep)
 
     # Launch a program if anything has changed.
@@ -204,16 +166,6 @@ class DBDownload(object):
                     self._logger.exception(e)
 
                 try:
-                    line = f.readline()  # Token.
-                    self._token = json.loads(line)
-                    self._logger.debug('loaded token')
-                except Exception as e:
-                    self._logger.warn('can\'t load cache state')
-                    self._logger.exception(e)
-                if dir_changed:
-                    return
-
-                try:
                     line = f.readline()  # Cursor.
                     self._cursor = json.loads(line)
                     self._logger.debug('loaded delta cursor')
@@ -223,7 +175,7 @@ class DBDownload(object):
 
                 try:
                     line = f.readline()  # Tree.
-                    self._tree = json.loads(line)
+                    self._tree = jsonpickle.decode(line)
                     self._logger.debug('loaded local tree')
                 except Exception as e:
                     self._logger.warn('can\'t load cache state')
@@ -236,14 +188,8 @@ class DBDownload(object):
     def _save_state(self):
         with open(os.path.expanduser(self.cache_file), 'w') as f:
             f.write(''.join([json.dumps(self.remote_dir), '\n']))
-            f.write(''.join([json.dumps(self._token), '\n']))
             f.write(''.join([json.dumps(self._cursor), '\n']))
-            f.write(''.join([json.dumps(self._tree), '\n']))
-
-    def _get_modt(self, modstr):
-        mod = timeparser.parse(modstr).astimezone(timezone.tzlocal())
-        t = time.mktime(mod.timetuple())
-        return t
+            f.write(''.join([jsonpickle.encode(self._tree), '\n']))
 
     # Check for files/folders missing or modified locally.
     def _check_missing(self):
@@ -253,18 +199,20 @@ class DBDownload(object):
         for key, meta in self._tree.items():
             if not meta:
                 continue
-            local_path = unicode(self._remote2local(meta['path']))
-            t = self._get_modt(meta.get('client_mtime', meta['modified']))
+            local_path = unicode(self._remote2local(meta.path_display))
+
             if not os.path.exists(local_path.encode('utf-8')):
-                if meta['is_dir']:
+                if type(meta) is dropbox.files.FolderMetadata:
                     dirs.append((key, local_path))
                 else:
+                    t = time.mktime(meta.client_modified.timetuple())
                     files.append((key, local_path, t))
-            elif not meta['is_dir']:
+            elif type(meta) is dropbox.files.FileMetadata:
+                t = time.mktime(meta.client_modified.timetuple())
                 stat = os.stat(local_path.encode('utf-8'))
                 if stat.st_mtime != t:
                     self._logger.debug(u'%s has been modified locally' %
-                                       (local_path))
+                                       local_path)
                     files.append((key, local_path, t))
 
         dirs.sort()  # Make sure we're creating them in order.
@@ -282,30 +230,27 @@ class DBDownload(object):
     # Apply any outstanding change.
     def _apply_delta(self, tree):
         self._logger.debug('applying changes in tree')
-        rm = [self._tree[n]['path'] for n in tree if not tree[n] and n in
+        rm = [self._tree[n].path_display for n in tree if not tree[n] and n in
               self._tree and self._tree[n]]
         rm.sort(reverse=True)
         for path in rm:
             self._remove(self._remote2local(path))  # Remove file/directory.
 
-        dirs = sorted([n for n in tree if tree[n] and tree[n]['is_dir']])
+        dirs = sorted([n for n in tree if tree[n] and type(tree[n]) is dropbox.files.FolderMetadata])
 
         for d in dirs:
-            rev = d in tree and tree[d]['revision'] or -1
-            oldrev = d in self._tree and self._tree[d]['revision'] or -1
-            if oldrev < rev:
-                local_path = self._remote2local(tree[d]['path'])
-                self._mkdir(local_path)
+            # Directories no longer have revision info in v2, so just make it regardless
+            self._mkdir(self._remote2local(tree[d].path_display))
 
-        files = [n for n in tree if tree[n] and not tree[n]['is_dir']]
+        files = [n for n in tree if tree[n] and type(tree[n]) is dropbox.files.FileMetadata]
 
         for f in files:
-            rev = f in tree and tree[f]['revision'] or -1
-            oldrev = f in self._tree and self._tree[f]['revision'] or -1
-            if oldrev < rev:
-                local_path = self._remote2local(tree[f]['path'])
-                self._get_file(f, local_path,
-                               self._get_modt(tree[f]['modified']))
+            rev = f in tree and tree[f].rev or -1
+            oldrev = f in self._tree and self._tree[f].rev or -1
+            # Revisions are no longer simple ints, so the best we can do is check equality, not order
+            if oldrev != rev:
+                local_path = self._remote2local(tree[f].path_display)
+                self._get_file(f, local_path, time.mktime(tree[f].client_modified.timetuple()))
 
     # Remove anything that is not in dropbox.
     def _cleanup_target(self):
@@ -318,9 +263,9 @@ class DBDownload(object):
                 path = os.path.join(root, d)
                 key = self._local2remote(path).lower()
                 if (key not in self._tree or
-                        self._remote2local(self._tree[key]['path']) != path):
+                        self._remote2local(self._tree[key].path_display) != path):
                     rmdirs.append(d)
-                    self._logger.info(u'RM -RF %s' % (path))
+                    self._logger.info(u'RM -RF %s' % path)
                     self._rmrf(path)
                     changed = True
 
@@ -331,8 +276,8 @@ class DBDownload(object):
                 path = os.path.join(root, f).decode('utf-8')
                 key = self._local2remote(path).lower()
                 if (key not in self._tree or
-                        self._remote2local(self._tree[key]['path']) != path):
-                    self._logger.info(u'RM %s' % (path))
+                        self._remote2local(self._tree[key].path_display) != path):
+                    self._logger.info(u'RM %s' % path)
                     self._rm(path)
                     changed = True
 
@@ -368,35 +313,14 @@ class DBDownload(object):
         self._logger.info(u'FETCH %s -> %s' %
                           (unicode(from_path), unicode(to_path)))
         try:
-            f, metadata = self.client.get_file_and_metadata(from_path)
+            self.client.files_download_to_file(to_path.encode('utf-8'), from_path.encode('utf-8'))
         except Exception as e:
             self._logger.error('error fetching file')
             self._logger.exception(e)
             return  # Will check later if we've got everything.
 
-        to_file = open(os.path.expanduser(to_path.encode('utf-8')), 'wb')
-        to_file.write(f.read())
-        to_file.close()
         if modified:
             os.utime(to_path.encode('utf-8'), (modified, modified))
-
-
-class DBSession(session.DropboxSession):
-
-    def link(self):
-        request_token = self.obtain_request_token()
-
-        url = self.build_authorize_url(request_token)
-        print 'URL:', url
-        print 'Please authorize this URL in the browser and then press enter'
-        raw_input()
-
-        self.obtain_access_token(request_token)
-        self.set_token(self.token.key, self.token.secret)
-        return [self.token.key, self.token.secret]
-
-    def unlink(self):
-        session.DropboxSession.unlink(self)
 
 
 class FakeSecHead(object):
@@ -419,7 +343,7 @@ def parse_config(cfg, opts):
     parser = SafeConfigParser()
     try:
         fp = open(os.path.expanduser(cfg), 'r')
-    except:
+    except Exception:
         print 'Warning: can\'t open %s, using default values' % cfg
         return
     parser.readfp(FakeSecHead(fp))
@@ -453,15 +377,17 @@ def create_logger(log, verbose):
 
 def main():
     options = {'log': '-', 'config': '~/dbdownload.conf',
-               'cache': '~/.dbdownload.cache', 'interval': 300, 'source': None,
-               'target': None, 'verbose': False, 'reset': False, 'exec': None,
-               'authorizeonly': False}
+               'cache': '~/.dbdownload.cache', 'token': None, 'interval': 300,
+               'source': None, 'target': None, 'verbose': False, 'reset': False,
+               'exec': None}
 
     # First parse any command line arguments.
     parser = OptionParser(description='Do one-way Dropbox synchronization')
     parser.add_option('--interval', '-i', type=int, help='check interval')
     parser.add_option('--config', '-c', help='configuration file')
     parser.add_option('--cache', '-a', help='cache file')
+    parser.add_option('--token', '-k', help='Access token '
+                      '(see https://www.dropbox.com/developers/apps)')
     parser.add_option('--log', '-l', help='logfile (pass - for console)')
     parser.add_option('--source', '-s',
                       help='source Dropbox directory to synchronize')
@@ -470,8 +396,6 @@ def main():
                       help='enable verbose logging')
     parser.add_option('--reset', '-r', action='store_true',
                       help='reset synchronization')
-    parser.add_option('--authorizeonly', '-u', action='store_true',
-                      help='only authorize application and exit')
     parser.add_option('--exec', '-x',
                       help='execute program when directory has changed')
     (opts, args) = parser.parse_args()
@@ -494,19 +418,23 @@ def main():
         sys.stderr.write('Error: %s\n' % error_msg)
         sys.exit(-1)
 
+    if not options['token']:
+        error_msg = 'Please provide authentication token.  See https://www.dropbox.com/developers/apps to obtain one.'
+        sys.stderr.write('Error: %s\n' % error_msg)
+        sys.exit(-1)
+
     locale.setlocale(locale.LC_ALL, 'C')  # To parse time correctly.
 
     logger = create_logger(options['log'], options['verbose'])
-    logger.info(u'*** DBdownload v%s starting up ***' % (VERSION))
+    logger.info(u'*** DBdownload v%s starting up ***' % VERSION)
 
     dl = DBDownload(options['source'], options['target'], options['cache'],
-                    options['interval'], options['exec'])
+                    options['token'], options['interval'], options['exec'])
     if options['reset']:
         dl.reset()
-    if not opts.authorizeonly:
-        dl.start()
-    else:
-        dl.reset()
+
+    dl.start()
 
 if __name__ == '__main__':
     main()
+

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'Topic :: Networking',
     ],
     license='Apache License, Version 2.0',
-    install_requires = ['dropbox>=2.0.0','python-dateutil>=2.0'],
+    install_requires = ['dropbox>=8.4.1', 'jsonpickle>=0.9.5'],
     entry_points = {
         'console_scripts': [
             'dbdownload = dbdownload:main',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='dbdownload',
-    version='0.2',
+    version='0.3',
     description='Simple Dropbox client written in Python',
     keywords="dropbox tools dbdownload",
     long_description=read('README.md'),


### PR DESCRIPTION
I've updated DBdownload to use the new v2 version of the Dropbox API, and have tested it on my personal account.  Main changes:

1. A new OAuth2 authentication flow is needed, with a verification code to enter into the app itself once the user has authorized it on their account.
2. The new delta equivalent now returns a list of FileMetadata and FolderMetadata objects, instead of raw dicts with is_dir set to True or False.  These need to be accessed differently, even though the same information is still available (more or less).  I've pulled in jsonpickle to allow saving the new complex _tree to the cache file.
3. The dropbox python library now has a convenience method that handles saving the file to disk for you, so I'm using that directly, rather than handling the writing in dbdownload itself.