### PR TITLE
Fix for issue 14: rewrite top-level path

### DIFF
--- a/dbdownload/dbdownload.py
+++ b/dbdownload/dbdownload.py
@@ -71,6 +71,8 @@ class DBDownload(object):
                                                self.remote_dir)
         if self.remote_dir.endswith(dropboxpath.sep):
             self.remote_dir, _ = dropboxpath.split(self.remote_dir)
+        if self.remote_dir == dropboxpath.sep:
+            self.remote_dir = ""
 
         self.local_dir = local_dir
 


### PR DESCRIPTION
When syncing the entire Dropbox by specifying the source path as a single "/",
the path passed to the Dropbox client library needs to be rewritten as the
empty string to work