### PR TITLE
Fix regression in cc7e26b0

### DIFF
--- a/dbdownload/dbdownload.py
+++ b/dbdownload/dbdownload.py
@@ -71,8 +71,6 @@ class DBDownload(object):
                                                self.remote_dir)
         if self.remote_dir.endswith(dropboxpath.sep):
             self.remote_dir, _ = dropboxpath.split(self.remote_dir)
-        if self.remote_dir == dropboxpath.sep:
-            self.remote_dir = ""
 
         self.local_dir = local_dir
 
@@ -149,7 +147,8 @@ class DBDownload(object):
             # If we don't have a cursor yet, call files_list_folder
             try:
                 if self._cursor is None:
-                    result = self.client.files_list_folder(self.remote_dir, recursive=True)
+                    remote_dir = "" if self.remote_dir == dropboxpath.sep else self.remote_dir
+                    result = self.client.files_list_folder(remote_dir, recursive=True)
                 else:
                     result = self.client.files_list_folder_continue(self._cursor)
             except Exception as e:


### PR DESCRIPTION
The previous patch created a resync loop by clobbering target directory when the sync had completed; this was due to a leading slash not being present when comparing the key to the cached key name in _is_deleted().

A better place to map "/" to "" is just before calling list_folder().